### PR TITLE
added --network host to workshop image run command

### DIFF
--- a/exercises/exercise_1/README.md
+++ b/exercises/exercise_1/README.md
@@ -67,7 +67,7 @@ Login Succeeded
 We prepared an image containing everything needed for the workshop (docker CLI, docker-compose, docker-app, swarm, ...) and your prefered editors (nano, emacs, even vi!). Please run it, everything will happen in this container. 
 
 ```sh
-$ docker run -it -v /var/run/docker.sock:/var/run/docker.sock -v /root/workshop:/workshop dapworkshop/workshop
+$ docker run -it -v /var/run/docker.sock:/var/run/docker.sock -v /root/workshop:/workshop --network host dapworkshop/workshop
 Unable to find image 'dapworkshop/workshop:latest' locally
 latest: Pulling from dapworkshop/workshop
 32802c0cfa4d: Pull complete


### PR DESCRIPTION
--network host is needed in play-with-docker to have exposed port be available from outside the host (through it) and the link be exposed in the play-with-docker gui
...that was the issue because the speaker was not able to reach the launched services in play-with-docker during the 3/12 dockercon eu 18 workshop